### PR TITLE
Removing module import.

### DIFF
--- a/ios/RNLinkedInSessionManager/RNLinkedInSessionManager.swift
+++ b/ios/RNLinkedInSessionManager/RNLinkedInSessionManager.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import LinkedinSwift
 
 @objc(RNLinkedInSessionManager)
 class RNLinkedInSessionManager: NSObject {


### PR DESCRIPTION
I am reverting a change that I submitted some time back. The reason I thought the fix was correct because I was incorrectly using cocoapods. I had use_frameworks! enabled in my Podfile due to which XCode would complain about missing Module. But I recently found out that the correct way to use react native with cocoapods here https://github.com/airbnb/react-native-maps/blob/master/example/ios/Podfile